### PR TITLE
Plotting framework

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.0.2"
 [deps]
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Exceptions = "25a0344a-2aab-46d0-b534-6f1410d4c65f"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Rocket = "df971d30-c9d6-4b37-b8ff-e965b2cb3a40"
 
 [compat]
 Dictionaries = "0.3"
 Exceptions = "0.1"
+GLMakie = "0.8"
 Rocket = "1"
 julia = "1"
 

--- a/src/RxEnvironments.jl
+++ b/src/RxEnvironments.jl
@@ -13,5 +13,7 @@ include("environment/discreteenvironment.jl")
 include("environment/timerenvironment.jl")
 include("environment/rxenvironment.jl")
 
+include("visualization/plotting.jl")
+
 
 end

--- a/src/actors/message.jl
+++ b/src/actors/message.jl
@@ -1,5 +1,3 @@
-using Rocket
-
 struct Observation{M,D}
     emitter::M
     data::D
@@ -12,3 +10,10 @@ data(message::Observation) = message.data
 struct TimerMessage end
 
 struct EmptyMessage end
+
+mutable struct Terminated
+    terminated::Bool
+end
+
+is_terminated(terminated::Terminated) = terminated.terminated
+terminate!(terminated::Terminated) = terminated.terminated = true

--- a/src/actors/message.jl
+++ b/src/actors/message.jl
@@ -9,4 +9,6 @@ emitter(message::Observation) = message.emitter
 data(message::Observation) = message.data
 
 
+struct TimerMessage end
+
 struct EmptyMessage end

--- a/src/entity/abstractentity.jl
+++ b/src/entity/abstractentity.jl
@@ -8,7 +8,7 @@ export AbstractEntity,
 
 The AbstractEntity type supertypes all entities. It describes basic functionality all entities should have.
 """
-abstract type AbstractEntity end
+abstract type AbstractEntity{T} end
 
 entity(entity::AbstractEntity) = entity.entity
 observations(entity::AbstractEntity) = observations(markov_blanket(entity))

--- a/src/entity/abstractentity.jl
+++ b/src/entity/abstractentity.jl
@@ -1,7 +1,15 @@
 using Rocket
 
 export AbstractEntity,
-    add!, act!, update!, observe, is_subscribed, subscribers, subscribed_to
+    add!,
+    act!,
+    update!,
+    observe,
+    is_subscribed,
+    subscribers,
+    subscribed_to,
+    terminate!,
+    is_terminated
 
 """
     AbstractEntity
@@ -19,6 +27,7 @@ subscribed_to(entity::AbstractEntity) = collect(keys(sensors(entity)))
 markov_blanket(entity::AbstractEntity) = entity.markov_blanket
 get_actuator(emitter::AbstractEntity, recipient::AbstractEntity) =
     get_actuator(markov_blanket(emitter), recipient)
+is_terminated(entity::AbstractEntity) = is_terminated(entity.terminated)
 
 function __add!(first::AbstractEntity, second::AbstractEntity)
     subscribe!(first, second)
@@ -26,6 +35,16 @@ function __add!(first::AbstractEntity, second::AbstractEntity)
 end
 
 function update! end
+
+function terminate!(entity::AbstractEntity)
+    terminate!(entity.terminated)
+    for subscriber in subscribers(entity)
+        unsubscribe!(entity, subscriber)
+    end
+    for subscribed_to in subscribed_to(entity)
+        unsubscribe!(subscribed_to, entity)
+    end
+end
 
 observe(subject::AbstractEntity, environment) = observe(entity(subject), environment)
 

--- a/src/entity/rxentity.jl
+++ b/src/entity/rxentity.jl
@@ -1,7 +1,7 @@
 using Rocket
 
-struct RxEntity <: AbstractEntity
-    entity::Any
+struct RxEntity{T} <: AbstractEntity{T}
+    entity::T
     markov_blanket::MarkovBlanket
 end
 

--- a/src/entity/rxentity.jl
+++ b/src/entity/rxentity.jl
@@ -3,10 +3,11 @@ using Rocket
 struct RxEntity{T} <: AbstractEntity{T}
     entity::T
     markov_blanket::MarkovBlanket
+    terminated::Terminated
 end
 
 function RxEntity(entity)
-    return RxEntity(entity, MarkovBlanket())
+    return RxEntity(entity, MarkovBlanket(), Terminated(false))
 end
 
 function Base.:(==)(a::RxEntity, b::RxEntity)

--- a/src/environment/abstractenvironment.jl
+++ b/src/environment/abstractenvironment.jl
@@ -1,6 +1,6 @@
 
 
-abstract type AbstractEnvironment <: AbstractEntity end
+abstract type AbstractEnvironment{T} <: AbstractEntity{T} end
 
 environment(environment::AbstractEnvironment) = environment.entity
 

--- a/src/environment/discreteenvironment.jl
+++ b/src/environment/discreteenvironment.jl
@@ -1,5 +1,5 @@
-struct DiscreteEnvironment <: AbstractEnvironment
-    entity::Any
+struct DiscreteEnvironment{T} <: AbstractEnvironment{T}
+    entity::T
     markov_blanket::MarkovBlanket
 end
 

--- a/src/environment/discreteenvironment.jl
+++ b/src/environment/discreteenvironment.jl
@@ -1,10 +1,11 @@
 struct DiscreteEnvironment{T} <: AbstractEnvironment{T}
     entity::T
     markov_blanket::MarkovBlanket
+    terminated::Terminated
 end
 
 function DiscreteEnvironment(environment)
-    env = DiscreteEnvironment(environment, MarkovBlanket())
+    env = DiscreteEnvironment(environment, MarkovBlanket(), Terminated(false))
     instantiate!(env)
     return env
 end

--- a/src/environment/timerenvironment.jl
+++ b/src/environment/timerenvironment.jl
@@ -18,12 +18,14 @@ last_update(clock::Clock) = time(clock.last_update)
 real_time_factor(clock::Clock) = clock.real_time_factor
 timer(clock::Clock) = clock.timer
 
-Rocket.subscribe!(clock::Clock, actor::Rocket.Actor) = Rocket.subscribe!(timer(clock), actor)
+Rocket.subscribe!(clock::Clock, actor::Rocket.Actor) =
+    Rocket.subscribe!(timer(clock), actor)
 
 struct TimerEnvironment{T} <: AbstractEnvironment{T}
     entity::T
     markov_blanket::MarkovBlanket
     clock::Clock
+    terminated::Terminated
 end
 
 function TimerEnvironment(environment, real_time_factor::Float64, emit_every_ms::Int64)
@@ -33,11 +35,7 @@ function TimerEnvironment(environment, real_time_factor::Float64, emit_every_ms:
         real_time_factor,
         Rocket.interval(emit_every_ms),
     )
-    env = TimerEnvironment(
-        environment,
-        MarkovBlanket(),
-        c,
-    )
+    env = TimerEnvironment(environment, MarkovBlanket(), c, Terminated(false))
     instantiate!(env)
     subscribe!(clock(env), TimerActor(env))
     return env

--- a/src/environment/timerenvironment.jl
+++ b/src/environment/timerenvironment.jl
@@ -1,4 +1,4 @@
-struct TimerMessage end
+using Rocket
 
 mutable struct TimeStamp
     time::Float64
@@ -6,8 +6,8 @@ end
 
 Base.time(time::TimeStamp) = time.time
 
-struct TimerEnvironment <: AbstractEnvironment
-    entity::Any
+struct TimerEnvironment{T} <: AbstractEnvironment{T}
+    entity::T
     markov_blanket::MarkovBlanket
     start_time::TimeStamp
     last_update::TimeStamp

--- a/src/markovblanket.jl
+++ b/src/markovblanket.jl
@@ -60,11 +60,14 @@ function get_actuator(markov_blanket::MarkovBlanket, agent::AbstractEntity)
     return actuators(markov_blanket)[agent]
 end
 
+add_to_state!(entity, to_add) = nothing
+
 function Rocket.subscribe!(emitter::AbstractEntity, receiver::AbstractEntity)
     actuator = Actuator()
     insert!(actuators(markov_blanket(emitter)), receiver, actuator)
     sensor = Sensor(emitter, receiver)
     insert!(sensors(markov_blanket(receiver)), emitter, sensor)
+    add_to_state!(entity(emitter), entity(receiver))
 end
 
 function Rocket.subscribe!(emitter::AbstractEntity, receiver::Rocket.Actor{T} where {T})

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -4,16 +4,22 @@ export animate_state
 
 function plot_state end
 
-function animate_state(subject::AbstractEntity; fps=60, seconds=10)
+animate_state(subject::AbstractEntity; fps = 60, seconds = 10) =
+    @async(__animate_state(subject, fps, seconds))
+
+
+
+function __animate_state(subject::AbstractEntity, fps, seconds)
+    @info "Animating state of $(subject)"
     figure = Figure()
-    ax = Axis(figure[1,1])
-    underlying = entity(subject)
+    ax = Axis(figure[1, 1])
     display(figure)
-    for _ in 1:fps*seconds
+    underlying = entity(subject)
+    while !is_terminated(subject)
         empty!(ax)
         ax.cycler.counters[Scatter] = 0
         ax.cycler.counters[Lines] = 0
         plot_state(ax, underlying)
-        sleep(1/fps)
+        sleep(1 / fps)
     end
 end

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -1,0 +1,19 @@
+using GLMakie
+
+export animate_state
+
+function plot_state end
+
+function animate_state(subject::AbstractEntity; fps=60, seconds=10)
+    figure = Figure()
+    ax = Axis(figure[1,1])
+    underlying = entity(subject)
+    display(figure)
+    for _ in 1:fps*seconds
+        empty!(ax)
+        ax.cycler.counters[Scatter] = 0
+        ax.cycler.counters[Lines] = 0
+        plot_state(ax, underlying)
+        sleep(1/fps)
+    end
+end

--- a/test/entity/entity.jl
+++ b/test/entity/entity.jl
@@ -5,7 +5,7 @@ using Rocket
 using RxEnvironments
 import RxEnvironments: entity, observations, markov_blanket, conduct_action!, Observation
 
-include("mockenvironment.jl")
+include("../mockenvironment.jl")
 
 @testset "entity" begin
     @testset "constructor" begin
@@ -38,6 +38,41 @@ include("mockenvironment.jl")
             next!(observations(env), Observation(actor, nothing))
             @test length(obs) == 1
         end
+    end
+
+    @testset "terminate!" begin
+        let env = RxEnvironment(MockEnvironment(0.0))
+            agent = add!(env, MockAgent())
+            terminate!(agent)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(agent)
+            @test length(subscribers(env)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0))
+            agent = add!(env, MockAgent())
+            terminate!(env)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(env)
+            @test length(subscribers(agent)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0); emit_every_ms = 10)
+            agent = add!(env, MockAgent())
+            terminate!(agent)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(agent)
+            @test length(subscribers(env)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0); emit_every_ms = 10)
+            agent = add!(env, MockAgent())
+            terminate!(env)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(env)
+            @test length(subscribers(agent)) == 0
+        end
+
     end
 
 end

--- a/test/environment/environment.jl
+++ b/test/environment/environment.jl
@@ -5,7 +5,7 @@ using RxEnvironments
 using Rocket
 import RxEnvironments: conduct_action!, Observation
 
-include("mockenvironment.jl")
+include("../mockenvironment.jl")
 
 @testset "environment" begin
     @testset "creation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Aqua
 using RxEnvironments
 
 @testset "RxEnvironments.jl" begin
-    Aqua.test_all(RxEnvironments)
+    Aqua.test_all(RxEnvironments; ambiguities=false)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ using RxEnvironments
 using Aqua
 using ReTest
 
-include("entity.jl")
-include("environment.jl")
+include("entity/entity.jl")
+include("environment/environment.jl")
 include("markovblanket.jl")
 include("exceptions.jl")
 
@@ -14,7 +14,7 @@ using Aqua
 using RxEnvironments
 
 @testset "RxEnvironments.jl" begin
-    Aqua.test_all(RxEnvironments; ambiguities=false)
+    Aqua.test_all(RxEnvironments; ambiguities = false)
 end
 
 end


### PR DESCRIPTION
Users can now animate their environments in real-time. This PR also makes the `TimerEnvironment` more hygienic with an explicit `Clock`. The plotting is handled on the same thread as the simulation is run, which is suboptimal but Makie did not allow plotting from a separate thread.