### PR TITLE
Refactor repo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.0.2"
 [deps]
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Exceptions = "25a0344a-2aab-46d0-b534-6f1410d4c65f"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Rocket = "df971d30-c9d6-4b37-b8ff-e965b2cb3a40"
 
 [compat]
 Dictionaries = "0.3"
 Exceptions = "0.1"
+GLMakie = "0.8"
 Rocket = "1"
 julia = "1"
 

--- a/src/RxEnvironments.jl
+++ b/src/RxEnvironments.jl
@@ -13,5 +13,7 @@ include("environment/discreteenvironment.jl")
 include("environment/timerenvironment.jl")
 include("environment/rxenvironment.jl")
 
+include("visualization/plotting.jl")
+
 
 end

--- a/src/RxEnvironments.jl
+++ b/src/RxEnvironments.jl
@@ -3,6 +3,7 @@ module RxEnvironments
 include("exceptions.jl")
 
 include("actors/message.jl")
+include("actors/timer.jl")
 
 include("actors/environmentactor.jl")
 include("entity/abstractentity.jl")

--- a/src/actors/message.jl
+++ b/src/actors/message.jl
@@ -6,9 +6,6 @@ end
 emitter(message::Observation) = message.emitter
 data(message::Observation) = message.data
 
-
-struct TimerMessage end
-
 struct EmptyMessage end
 
 mutable struct Terminated

--- a/src/actors/message.jl
+++ b/src/actors/message.jl
@@ -1,5 +1,3 @@
-using Rocket
-
 struct Observation{M,D}
     emitter::M
     data::D
@@ -9,4 +7,13 @@ emitter(message::Observation) = message.emitter
 data(message::Observation) = message.data
 
 
+struct TimerMessage end
+
 struct EmptyMessage end
+
+mutable struct Terminated
+    terminated::Bool
+end
+
+is_terminated(terminated::Terminated) = terminated.terminated
+terminate!(terminated::Terminated) = terminated.terminated = true

--- a/src/actors/timer.jl
+++ b/src/actors/timer.jl
@@ -1,0 +1,58 @@
+using Rocket
+
+struct TimerMessage end
+
+act!(recepient, action::TimerMessage) = nothing
+
+
+mutable struct TimeStamp
+    time::Float64
+end
+
+Base.time(time::TimeStamp) = time.time
+
+struct Clock
+    start_time::TimeStamp
+    last_update::TimeStamp
+    real_time_factor::Real
+    timer::Rocket.TimerObservable
+end
+
+Clock(real_time_factor, emit_every_ms) = Clock(
+    TimeStamp(time()),
+    TimeStamp(0),
+    real_time_factor,
+    Rocket.interval(emit_every_ms),
+)
+
+start_time(clock::Clock) = time(clock.start_time)
+last_update(clock::Clock) = time(clock.last_update)
+set_last_update!(clock::Clock, time::Real) = clock.last_update.time = time
+real_time_factor(clock::Clock) = clock.real_time_factor
+timer(clock::Clock) = clock.timer
+
+Rocket.subscribe!(clock::Clock, actor::Rocket.Actor) =
+    Rocket.subscribe!(timer(clock), actor)
+
+function Base.time(clock::Clock)
+    return (time() - start_time(clock)) / real_time_factor(clock)
+end
+
+
+function elapsed_time(clock::Clock)
+    return time(clock) - last_update(clock)
+end
+    
+struct TimerActor{T} <: Rocket.Actor{Int}
+    entity::T
+end
+
+entity(actor::TimerActor) = actor.entity
+
+function Rocket.on_next!(actor::TimerActor, time::Int)
+    next!(observations(entity(actor)), TimerMessage())
+end
+
+function Rocket.on_error!(actor::TimerActor, error)
+    @error "Error in TimerActor for entity " exception = (error, catch_backtrace())
+end

--- a/src/entity/abstractentity.jl
+++ b/src/entity/abstractentity.jl
@@ -78,3 +78,14 @@ end
 function is_subscribed(subject::Rocket.Actor{Any}, target::AbstractEntity)
     return haskey(actuators(markov_blanket(target)), subject)
 end
+
+function add_timer!(entity::AbstractEntity, emit_every_ms; real_time_factor::Real=1.0)
+    @assert real_time_factor > 0.0
+    c = Clock(real_time_factor, emit_every_ms)
+    add_timer!(entity, c)
+end
+
+function add_timer!(entity::AbstractEntity, clock::Clock)
+    actor = TimerActor(entity)
+    subscribe!(timer(clock), actor)
+end

--- a/src/entity/abstractentity.jl
+++ b/src/entity/abstractentity.jl
@@ -1,14 +1,22 @@
 using Rocket
 
 export AbstractEntity,
-    add!, act!, update!, observe, is_subscribed, subscribers, subscribed_to
+    add!,
+    act!,
+    update!,
+    observe,
+    is_subscribed,
+    subscribers,
+    subscribed_to,
+    terminate!,
+    is_terminated
 
 """
     AbstractEntity
 
 The AbstractEntity type supertypes all entities. It describes basic functionality all entities should have.
 """
-abstract type AbstractEntity end
+abstract type AbstractEntity{T} end
 
 entity(entity::AbstractEntity) = entity.entity
 observations(entity::AbstractEntity) = observations(markov_blanket(entity))
@@ -19,6 +27,7 @@ subscribed_to(entity::AbstractEntity) = collect(keys(sensors(entity)))
 markov_blanket(entity::AbstractEntity) = entity.markov_blanket
 get_actuator(emitter::AbstractEntity, recipient::AbstractEntity) =
     get_actuator(markov_blanket(emitter), recipient)
+is_terminated(entity::AbstractEntity) = is_terminated(entity.terminated)
 
 function __add!(first::AbstractEntity, second::AbstractEntity)
     subscribe!(first, second)
@@ -26,6 +35,16 @@ function __add!(first::AbstractEntity, second::AbstractEntity)
 end
 
 function update! end
+
+function terminate!(entity::AbstractEntity)
+    terminate!(entity.terminated)
+    for subscriber in subscribers(entity)
+        unsubscribe!(entity, subscriber)
+    end
+    for subscribed_to in subscribed_to(entity)
+        unsubscribe!(subscribed_to, entity)
+    end
+end
 
 observe(subject::AbstractEntity, environment) = observe(entity(subject), environment)
 

--- a/src/entity/abstractentity.jl
+++ b/src/entity/abstractentity.jl
@@ -12,9 +12,11 @@ export AbstractEntity,
     is_terminated
 
 """
-    AbstractEntity
+    AbstractEntity{T}
 
-The AbstractEntity type supertypes all entities. It describes basic functionality all entities should have.
+The AbstractEntity type supertypes all entities. It describes basic functionality all entities should have. It is assumed that every 
+entity has a markov blanket, which has actuators and sensors. The AbstractEntity also has a field that describes whether or not the
+entity is terminated. 
 """
 abstract type AbstractEntity{T} end
 
@@ -29,7 +31,11 @@ get_actuator(emitter::AbstractEntity, recipient::AbstractEntity) =
     get_actuator(markov_blanket(emitter), recipient)
 is_terminated(entity::AbstractEntity) = is_terminated(entity.terminated)
 
-function __add!(first::AbstractEntity, second::AbstractEntity)
+"""
+
+
+"""
+function add!(first::AbstractEntity, second::AbstractEntity)
     subscribe!(first, second)
     subscribe!(second, first)
 end

--- a/src/entity/rxentity.jl
+++ b/src/entity/rxentity.jl
@@ -1,12 +1,13 @@
 using Rocket
 
-struct RxEntity <: AbstractEntity
-    entity::Any
+struct RxEntity{T} <: AbstractEntity{T}
+    entity::T
     markov_blanket::MarkovBlanket
+    terminated::Terminated
 end
 
 function RxEntity(entity)
-    return RxEntity(entity, MarkovBlanket())
+    return RxEntity(entity, MarkovBlanket(), Terminated(false))
 end
 
 function Base.:(==)(a::RxEntity, b::RxEntity)

--- a/src/environment/abstractenvironment.jl
+++ b/src/environment/abstractenvironment.jl
@@ -10,12 +10,16 @@ function instantiate!(environment::AbstractEnvironment)
 end
 
 
-function add!(environment::AbstractEnvironment, entity)
+function add!(environment::AbstractEntity, entity)
     entity = RxEntity(entity)
-    __add!(environment, entity)
+    add!(environment, entity)
     return entity
 end
 
-add!(environment::AbstractEnvironment, entity::AbstractEntity) = __add!(environment, entity)
+"""
+    RxEnvironments.update!()
 
+Updates the environment in the absence of any observations coming through the Markov Blanket. In a `TimedEnvironment` this will also take
+the `elapsed_time` as an argument in order to calcualte the state transition for the required time.
+"""
 function update! end

--- a/src/environment/abstractenvironment.jl
+++ b/src/environment/abstractenvironment.jl
@@ -1,6 +1,6 @@
 
 
-abstract type AbstractEnvironment <: AbstractEntity end
+abstract type AbstractEnvironment{T} <: AbstractEntity{T} end
 
 environment(environment::AbstractEnvironment) = environment.entity
 

--- a/src/environment/discreteenvironment.jl
+++ b/src/environment/discreteenvironment.jl
@@ -1,10 +1,11 @@
-struct DiscreteEnvironment <: AbstractEnvironment
-    entity::Any
+struct DiscreteEnvironment{T} <: AbstractEnvironment{T}
+    entity::T
     markov_blanket::MarkovBlanket
+    terminated::Terminated
 end
 
 function DiscreteEnvironment(environment)
-    env = DiscreteEnvironment(environment, MarkovBlanket())
+    env = DiscreteEnvironment(environment, MarkovBlanket(), Terminated(false))
     instantiate!(env)
     return env
 end

--- a/src/environment/timerenvironment.jl
+++ b/src/environment/timerenvironment.jl
@@ -1,25 +1,5 @@
 using Rocket
 
-mutable struct TimeStamp
-    time::Float64
-end
-
-Base.time(time::TimeStamp) = time.time
-
-struct Clock
-    start_time::TimeStamp
-    last_update::TimeStamp
-    real_time_factor::Real
-    timer::Rocket.TimerObservable
-end
-
-start_time(clock::Clock) = time(clock.start_time)
-last_update(clock::Clock) = time(clock.last_update)
-real_time_factor(clock::Clock) = clock.real_time_factor
-timer(clock::Clock) = clock.timer
-
-Rocket.subscribe!(clock::Clock, actor::Rocket.Actor) =
-    Rocket.subscribe!(timer(clock), actor)
 
 struct TimerEnvironment{T} <: AbstractEnvironment{T}
     entity::T
@@ -29,15 +9,10 @@ struct TimerEnvironment{T} <: AbstractEnvironment{T}
 end
 
 function TimerEnvironment(environment, real_time_factor::Float64, emit_every_ms::Int64)
-    c = Clock(
-        TimeStamp(time()),
-        TimeStamp(0),
-        real_time_factor,
-        Rocket.interval(emit_every_ms),
-    )
+    c = Clock(real_time_factor, emit_every_ms)
     env = TimerEnvironment(environment, MarkovBlanket(), c, Terminated(false))
     instantiate!(env)
-    subscribe!(clock(env), TimerActor(env))
+    add_timer!(env, c)
     return env
 end
 
@@ -55,36 +30,7 @@ function Base.show(io::IO, environment::TimerEnvironment)
     )
 end
 
-function set_last_update!(environment::TimerEnvironment, time::Float64)
-    environment.clock.last_update.time = time
-end
-
-function Base.time(environment::AbstractEnvironment)
-    return (time() - start_time(environment)) / real_time_factor(environment)
-end
-
-function elapsed_time(environment::TimerEnvironment)
-    return time(environment) - last_update(environment)
-end
-
 function update!(env::TimerEnvironment)
-    update!(environment(env), elapsed_time(env))
-    set_last_update!(env, time(env))
+    update!(environment(env), elapsed_time(clock(env)))
+    set_last_update!(clock(env), time(clock(env)))
 end
-
-struct TimerActor <: Rocket.Actor{Int}
-    environment::TimerEnvironment
-end
-
-environment(actor::TimerActor) = actor.environment
-
-function Rocket.on_next!(actor::TimerActor, time::Int)
-    next!(observations(environment(actor)), TimerMessage())
-end
-
-function Rocket.on_error!(actor::TimerActor, error)
-    @error "Error in TimerActor for environment " exception = (error, catch_backtrace())
-end
-
-
-act!(recepient::TimerEnvironment, action::TimerMessage) = nothing

--- a/src/environment/timerenvironment.jl
+++ b/src/environment/timerenvironment.jl
@@ -1,4 +1,4 @@
-struct TimerMessage end
+using Rocket
 
 mutable struct TimeStamp
     time::Float64
@@ -6,42 +6,57 @@ end
 
 Base.time(time::TimeStamp) = time.time
 
-struct TimerEnvironment <: AbstractEnvironment
-    entity::Any
-    markov_blanket::MarkovBlanket
+struct Clock
     start_time::TimeStamp
     last_update::TimeStamp
-    real_time_factor::Float64
+    real_time_factor::Real
     timer::Rocket.TimerObservable
 end
 
+start_time(clock::Clock) = time(clock.start_time)
+last_update(clock::Clock) = time(clock.last_update)
+real_time_factor(clock::Clock) = clock.real_time_factor
+timer(clock::Clock) = clock.timer
+
+Rocket.subscribe!(clock::Clock, actor::Rocket.Actor) =
+    Rocket.subscribe!(timer(clock), actor)
+
+struct TimerEnvironment{T} <: AbstractEnvironment{T}
+    entity::T
+    markov_blanket::MarkovBlanket
+    clock::Clock
+    terminated::Terminated
+end
+
 function TimerEnvironment(environment, real_time_factor::Float64, emit_every_ms::Int64)
-    env = TimerEnvironment(
-        environment,
-        MarkovBlanket(),
+    c = Clock(
         TimeStamp(time()),
         TimeStamp(0),
         real_time_factor,
         Rocket.interval(emit_every_ms),
     )
+    env = TimerEnvironment(environment, MarkovBlanket(), c, Terminated(false))
     instantiate!(env)
-    subscribe!(env.timer, TimerActor(env))
+    subscribe!(clock(env), TimerActor(env))
     return env
 end
 
-start_time(environment::TimerEnvironment) = time(environment.start_time)
-last_update(environment::TimerEnvironment) = time(environment.last_update)
-real_time_factor(environment::TimerEnvironment) = environment.real_time_factor
+clock(environment::TimerEnvironment) = environment.clock
+
+start_time(environment::TimerEnvironment) = start_time(clock(environment))
+last_update(environment::TimerEnvironment) = last_update(clock(environment))
+real_time_factor(environment::TimerEnvironment) = real_time_factor(clock(environment))
+timer(environment::TimerEnvironment) = timer(clock(environment))
 
 function Base.show(io::IO, environment::TimerEnvironment)
     println(
         io,
-        "Timed RxEnvironment, emitting every $(environment.timer.period) milliseconds, on a clock speed of $(environment.real_time_factor) times real time.",
+        "Timed RxEnvironment, emitting every $(timer(environment).period) milliseconds, on a clock speed of $(real_time_factor(environment)) times real time.",
     )
 end
 
 function set_last_update!(environment::TimerEnvironment, time::Float64)
-    environment.last_update.time = time
+    environment.clock.last_update.time = time
 end
 
 function Base.time(environment::AbstractEnvironment)

--- a/src/markovblanket.jl
+++ b/src/markovblanket.jl
@@ -60,11 +60,14 @@ function get_actuator(markov_blanket::MarkovBlanket, agent::AbstractEntity)
     return actuators(markov_blanket)[agent]
 end
 
+add_to_state!(entity, to_add) = nothing
+
 function Rocket.subscribe!(emitter::AbstractEntity, receiver::AbstractEntity)
     actuator = Actuator()
     insert!(actuators(markov_blanket(emitter)), receiver, actuator)
     sensor = Sensor(emitter, receiver)
     insert!(sensors(markov_blanket(receiver)), emitter, sensor)
+    add_to_state!(entity(emitter), entity(receiver))
 end
 
 function Rocket.subscribe!(emitter::AbstractEntity, receiver::Rocket.Actor{T} where {T})

--- a/src/visualization/plotting.jl
+++ b/src/visualization/plotting.jl
@@ -1,0 +1,25 @@
+using GLMakie
+
+export animate_state
+
+function plot_state end
+
+animate_state(subject::AbstractEntity; fps = 60, seconds = 10) =
+    @async(__animate_state(subject, fps, seconds))
+
+
+
+function __animate_state(subject::AbstractEntity, fps, seconds)
+    @info "Animating state of $(subject)"
+    figure = Figure()
+    ax = Axis(figure[1, 1])
+    display(figure)
+    underlying = entity(subject)
+    while !is_terminated(subject)
+        empty!(ax)
+        ax.cycler.counters[Scatter] = 0
+        ax.cycler.counters[Lines] = 0
+        plot_state(ax, underlying)
+        sleep(1 / fps)
+    end
+end

--- a/test/entity/entity.jl
+++ b/test/entity/entity.jl
@@ -18,7 +18,7 @@ include("../mockenvironment.jl")
     end
 
     @testset "mutual subscribe" begin
-        import RxEnvironments: __add!, subscribe_to_observations!, data
+        import RxEnvironments: subscribe_to_observations!, data
         let first_entity = RxEntity(MockAgent())
             let second_entity = RxEntity(MockAgent())
                 add!(first_entity, second_entity)

--- a/test/entity/entity.jl
+++ b/test/entity/entity.jl
@@ -21,7 +21,7 @@ include("../mockenvironment.jl")
         import RxEnvironments: __add!, subscribe_to_observations!, data
         let first_entity = RxEntity(MockAgent())
             let second_entity = RxEntity(MockAgent())
-                __add!(first_entity, second_entity)
+                add!(first_entity, second_entity)
                 @test is_subscribed(first_entity, second_entity)
                 @test is_subscribed(second_entity, first_entity)
             end

--- a/test/entity/entity.jl
+++ b/test/entity/entity.jl
@@ -5,7 +5,7 @@ using Rocket
 using RxEnvironments
 import RxEnvironments: entity, observations, markov_blanket, conduct_action!, Observation
 
-include("mockenvironment.jl")
+include("../mockenvironment.jl")
 
 @testset "entity" begin
     @testset "constructor" begin
@@ -38,6 +38,41 @@ include("mockenvironment.jl")
             next!(observations(env), Observation(actor, nothing))
             @test length(obs) == 1
         end
+    end
+
+    @testset "terminate!" begin
+        let env = RxEnvironment(MockEnvironment(0.0))
+            agent = add!(env, MockAgent())
+            terminate!(agent)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(agent)
+            @test length(subscribers(env)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0))
+            agent = add!(env, MockAgent())
+            terminate!(env)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(env)
+            @test length(subscribers(agent)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0); emit_every_ms = 10)
+            agent = add!(env, MockAgent())
+            terminate!(agent)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(agent)
+            @test length(subscribers(env)) == 0
+        end
+
+        let env = RxEnvironment(MockEnvironment(0.0); emit_every_ms = 10)
+            agent = add!(env, MockAgent())
+            terminate!(env)
+            @test !is_subscribed(agent, env)
+            @test is_terminated(env)
+            @test length(subscribers(agent)) == 0
+        end
+
     end
 
 end

--- a/test/environment/environment.jl
+++ b/test/environment/environment.jl
@@ -5,7 +5,7 @@ using RxEnvironments
 using Rocket
 import RxEnvironments: conduct_action!, Observation
 
-include("mockenvironment.jl")
+include("../mockenvironment.jl")
 
 @testset "environment" begin
     @testset "creation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ using RxEnvironments
 using Aqua
 using ReTest
 
-include("entity.jl")
-include("environment.jl")
+include("entity/entity.jl")
+include("environment/environment.jl")
 include("markovblanket.jl")
 include("exceptions.jl")
 
@@ -14,7 +14,7 @@ using Aqua
 using RxEnvironments
 
 @testset "RxEnvironments.jl" begin
-    Aqua.test_all(RxEnvironments)
+    Aqua.test_all(RxEnvironments; ambiguities = false)
 end
 
 end


### PR DESCRIPTION
Very big PR containing:

- MarkovBlanket now parameterized with StateSpace type
- Entity now contains parameters whether its an environment, general entity, continuous or discrete
- TimerEnvironment and DiscreteEnvironment do not exist anymore, they are RxEntities with special properties
- Fixed bug where 2 non-environment entities could not respond to a message sent from one to another
- Plotting framework
- Observations by Discrete environments are stored in local buffer and sent when all subscribed agents have produced an action (this now also holds for Entities in general)

Version 0.1.0 is ready imo, I'm just going to tweak code quality and test coverage before publishing